### PR TITLE
💩 hack to disable autocomplete on visitor signup

### DIFF
--- a/client/src/visitors/components/signup_form.js
+++ b/client/src/visitors/components/signup_form.js
@@ -1,3 +1,12 @@
+/*
+ * Visitor Signup Form
+ *
+ * Note: This component requires a UUID prop to be passed from its parent.
+ * This is used to create unique field names in order to prevent browser autocomplete
+ * displaying past results.
+ *
+ * See https://github.com/TwinePlatform/twine-visitor/issues/423
+ */
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
@@ -52,17 +61,47 @@ const genders = [
   { key: '4', value: 'prefer not to say' },
 ];
 
+
 const signupForm = props => (
   <FlexContainerCol>
     <CenteredHeading>Please tell us about yourself</CenteredHeading>
     <Form className="SignupForm" onChange={props.handleChange} onSubmit={props.createVisitor}>
       <FormSection flexOrder={1}>
         <div>
-          <LabelledInput label="Full Name" name="fullname" option="fullname" error={props.errors.formSender && VISITOR_NAME_INVALID} required />
-          <LabelledInput label="Email Address" name="email" option="email" error={props.errors.formEmail} required />
-          <LabelledInput label="Phone Number (optional)" name="phone" option="phone" error={props.errors.formPhone} />
-          <LabelledSelect name="gender" label="Gender" options={genders} error={props.errors.formGender} required />
-          <LabelledSelect name="year" label="Year of Birth" options={props.years} error={props.errors.formYear} required />
+          <LabelledInput
+            label="Full Name"
+            name={`fullname$${props.uuid}`}
+            type="text"
+            error={props.errors.formSender && VISITOR_NAME_INVALID}
+            required
+          />
+          <LabelledInput
+            label="Email Address"
+            name={`email$${props.uuid}`}
+            type="email"
+            error={props.errors.formEmail}
+            required
+          />
+          <LabelledInput
+            label="Phone Number (optional)"
+            name={`phone$${props.uuid}`}
+            type="text"
+            error={props.errors.formPhone}
+          />
+          <LabelledSelect
+            name="gender"
+            label="Gender"
+            options={genders}
+            error={props.errors.formGender}
+            required
+          />
+          <LabelledSelect
+            name="year"
+            label="Year of Birth"
+            options={props.years}
+            error={props.errors.formYear}
+            required
+          />
         </div>
       </FormSection>
       <FormSection flexOrder={2}>
@@ -105,6 +144,7 @@ signupForm.propTypes = {
   errors: PropTypes.arrayOf(PropTypes.object).isRequired,
   cbOrgName: PropTypes.string.isRequired,
   handleChange: PropTypes.func.isRequired,
+  uuid: PropTypes.string.isRequired, // See header comment
 };
 
 export default signupForm;

--- a/client/src/visitors/pages/main.js
+++ b/client/src/visitors/pages/main.js
@@ -110,6 +110,7 @@ export default class Main extends Component {
       cbLogoUrl: '',
       isPrinting: false,
       cbOrgName: '',
+      formAutocompleteUUID: '', // See header comment in visitors/components/signup_form
     };
   }
 
@@ -119,6 +120,7 @@ export default class Main extends Component {
         this.setState({
           cbOrgName: res.data.result.cbOrgName,
           cbLogoUrl: res.data.result.cbLogoUrl,
+          formAutocompleteUUID: Date.now().toString(),
         }),
       );
   }
@@ -132,12 +134,18 @@ export default class Main extends Component {
   }
 
   handleChange = (e) => {
+    // TODO: This is necessary because the fix for the autocomplete
+    // in visitor/components/signup_form leaks into its parent component.
+    // In order to fix this, the form needs to be a stateful component
+    // with a consistent interface with its parent.
+    // See https://github.com/TwinePlatform/twine-visitor/issues/425
+    const name = e.target.name.split('$')[0];
     switch (e.target.type) {
       case 'checkbox':
-        this.setState({ [e.target.name]: e.target.checked });
+        this.setState({ [name]: e.target.checked });
         break;
       default:
-        this.setState({ [e.target.name]: e.target.value });
+        this.setState({ [name]: e.target.value });
         break;
     }
   };
@@ -215,6 +223,7 @@ export default class Main extends Component {
       </NotPrint>
     );
   }
+
   render() {
     const { errors, cbOrgName } = this.state;
 
@@ -228,6 +237,7 @@ export default class Main extends Component {
               years={years}
               createVisitor={this.createVisitor}
               cbOrgName={cbOrgName}
+              uuid={this.state.formAutocompleteUUID}
             />
           </Route>
 

--- a/docs/dev_notes.md
+++ b/docs/dev_notes.md
@@ -7,6 +7,7 @@
 3. [PdfMake an Image Content Types](#pdfmake-and-image-content-types)
 4. [NODE_ENV performance implications](#NODE-ENV-performance-implications)
 5. [Cleaning up resources in React Components](#cleaning-up-resources-in-react-components)
+6. [Form autocomplete](#form-autocomplete)
 
 ## Database Time Zones
 All `date` data types in schema are set as `TIMESTAMP WITH TIME ZONE`, with entries being added as UTC in the following format `2017-05-15 12:24:56+00`. Without `TIME ZONE` added node servers will convert `date` data into js time objects in local time.
@@ -26,3 +27,10 @@ Be careful to clean up after yourself! Temporary resources instantiated or used 
 
 **Example: Instascan scanner**
 The instascan scanner activates a given camera and uses the media feed to detect QR codes. If a reference to an instance of `scanner` is left around while the camera is active, it will not be garbage collected, and continue to attempt to interact with elements that may have already been unmounted. In addition, the camera will remain active unnecessarily unless `scanner.stop` is called. This is what caused [issue #411](https://github.com/TwinePlatform/DataPower/issues/411).
+
+## Form autocomplete
+Attempting to disable autocomplete on input fields is basically ignored by all modern browsers.
+
+See:
+* https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion
+* https://caniuse.com/#search=autocomplete


### PR DESCRIPTION
Fixes #423

#### Changes
Generate UUID to append onto field names on component mount to prevent
browser autocompleting fields from its cache.

#### Checklist
##### Fixing Bugs
* [x] Have I documented any necessary developer notes/gotchas/lessons learnt from this bug fix?