### PR TITLE
🐛 fix cb password reset validation issues

### DIFF
--- a/client/src/cb-admin/pages/ResetPassword.js
+++ b/client/src/cb-admin/pages/ResetPassword.js
@@ -7,6 +7,7 @@ import { Heading } from '../../shared/components/text/base';
 import { FlexContainerCol } from '../../shared/components/layout/base';
 import { Form, FormSection, PrimaryButton } from '../../shared/components/form/base';
 import LabelledInput from '../../shared/components/form/LabelledInput';
+import { colors } from '../../shared/style_guide';
 
 const payloadFromState = pick(['password', 'passwordConfirm']);
 const getErrorStatus = pathOr(null, ['response', 'status']);
@@ -18,6 +19,15 @@ const SubmitButton = styled(PrimaryButton) `
   width: 90%;
 `;
 
+const ErrorText = styled.p`
+  margin-top: 1em;
+  color: ${colors.error};
+  display: ${props => (props.show ? 'block' : 'none')};
+`;
+
+const FormSectionFixedHeight = styled(FormSection)`
+  height: 70%
+`;
 
 export default class ResetPassword extends React.Component {
   constructor(props) {
@@ -63,7 +73,7 @@ export default class ResetPassword extends React.Component {
       <FlexContainerCol>
         <Heading> Reset Password </Heading>
         <Form onChange={this.onChange} onSubmit={this.onSubmit}>
-          <FormSection>
+          <FormSectionFixedHeight>
             <LabelledInput
               id="cb-admin-new-password"
               label="New password"
@@ -81,7 +91,13 @@ export default class ResetPassword extends React.Component {
               required
             />
             <SubmitButton type="submit">SUBMIT</SubmitButton>
-          </FormSection>
+            <ErrorText show={this.state.errors.password === 'is too weak'}>
+              <li>Use at least 8 characters</li>
+              <li>Use uppercase and lowercase characters</li>
+              <li>Use 1 or more numbers</li>
+              <li>Use 1 or more special characters</li>
+            </ErrorText>
+          </FormSectionFixedHeight>
         </Form>
       </FlexContainerCol>
     );

--- a/server/routes/cbauthentication/__tests__/cb_password_change.test.js
+++ b/server/routes/cbauthentication/__tests__/cb_password_change.test.js
@@ -67,7 +67,7 @@ test('POST /api/cb/pwd/change | invalid token', (t) => {
     .expect('Content-Type', /json/)
     .end((err, res) => {
       t.notOk(err, err || 'Passes supertest expect criteria');
-      t.deepEqual(res.body, { result: null, error: 'Token not recognised' }, 'failed to log in with invalid token');
+      t.deepEqual(res.body, { result: null, error: 'Token not recognised. Reset password again.' }, 'failed to log in with invalid token');
       dbConnection.end(t.end);
     });
 });
@@ -98,7 +98,7 @@ test('POST /api/cb/pwd/change | expired token', async (t) => {
     .expect('Content-Type', /json/)
     .end(async (err, res) => {
       t.notOk(err, err || 'Passes supertest expect criteria');
-      t.deepEqual(res.body, { result: null, error: 'Token expired' }, 'failed to log in with expired token');
+      t.deepEqual(res.body, { result: null, error: 'Token expired. Reset password again.' }, 'failed to log in with expired token');
       dbConnection.end(t.end);
     });
 });

--- a/server/routes/cbauthentication/cb_password_change.js
+++ b/server/routes/cbauthentication/cb_password_change.js
@@ -13,7 +13,7 @@ const schemas = {
     token: Joi.string().required(),
 
     password: Joi.string()
-      .regex(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#$%^&*])(?=.{8,})/, 'strong_pwd')
+      .regex(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!#$%&()*+,\-./\\:;<=>@[\]^_{|}~?])(?=.{8,})/, 'strong_pwd')
       .required()
       .options({ language: { string: { regex: { name: 'is too weak' } } } }),
 
@@ -35,11 +35,11 @@ router.post('/', validate(schemas), async (req, res, next) => {
     const notExpired = await checkExpire(pgClient, token);
 
     if (!exists) {
-      return next(Boom.unauthorized('Token not recognised'));
+      return next(Boom.unauthorized('Token not recognised. Reset password again.'));
     }
 
     if (!notExpired) {
-      return next(Boom.unauthorized('Token expired'));
+      return next(Boom.unauthorized('Token expired. Reset password again.'));
     }
 
     const hashedPwd = await saltedHash(password);

--- a/server/routes/cbauthentication/cb_password_reset.js
+++ b/server/routes/cbauthentication/cb_password_reset.js
@@ -14,7 +14,7 @@ const schemas = {
   },
 };
 
-const TTL_TOKEN = 1000 * 60 * 60 * 1; // 1 hour
+const TTL_TOKEN = 1000 * 60 * 60 * 1 * 24; // 1 day
 
 router.post('/', validate(schemas), async (req, res, next) => {
   const { email } = req.body;


### PR DESCRIPTION
Changes:
- add more special characters to regex
- extend token lifespan to 1 day
- clarify error messages
- add password strength critera on client


Fixes #519