### PR TITLE
♻️ unregister service worker

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import './styles/index.css';
 import './styles/DatePicker.css';
 import './styles/ReactPagination.css';
 import App from './App';
-import registerServiceWorker from './registerServiceWorker';
+import { unregister } from './registerServiceWorker';
 
 ReactDOM.render(
   <BrowserRouter>
@@ -14,4 +14,4 @@ ReactDOM.render(
   </BrowserRouter>,
   document.getElementById('root'),
 );
-registerServiceWorker();
+unregister();


### PR DESCRIPTION
We don't need the service worker, and it's preventing the visitor app from updating properly.