### PR TITLE
🐛 fix proxy issues

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,11 +1,6 @@
 {
   "name": "twine-visitor",
   "scripts": {},
-  "env": {
-    "REACT_APP_API_HOST_DOMAIN": {
-      "required": true
-    }
-  },
   "formation": {
     "web": {
       "quantity": 1

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ app.use(compression());
 // Serve static files in "build" directory
 app.use(express.static(path.join(__dirname, 'build')));
 
-// All unmatched GET requests should serve "index.html"
+// All unmatched GET requests should serve "index.html" for refeshing on nested routes
 app.use((_, res) => res.sendFile(path.resolve(__dirname, 'build', 'index.html')));
 
 // Start server

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -5,7 +5,9 @@ import _axios, { create } from 'axios';
 import { pathOr, equals, compose } from 'ramda';
 import qs from 'qs';
 
-const baseURL = `${process.env.REACT_APP_API_HOST_DOMAIN}/v1`;
+const baseURL = process.env.REACT_APP_API_HOST_DOMAIN ?
+  `${process.env.REACT_APP_API_HOST_DOMAIN}/v1`
+  : '/v1';
 
 export const axios = create({
   baseURL,


### PR DESCRIPTION
#### Changes
- build base url dependant on wether HOST_DOMAIN is set
- remove HOST_DOMAIN from required env vars in heroku config

Heroku changes:
- added `PROXY_API_URL` to staging and PR pipelines for test apps. Previously experiencing cors issues

@eliascodes with the removed heroku config, we may want to throw an error on start if either `PROXY_API_URL` or `REACT_APP_API_HOST_DOMAIN` isn't set