### PR TITLE
🐛 fix 404 routing for nested routes

### DIFF
--- a/src/cb_admin/index.js
+++ b/src/cb_admin/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route } from 'react-router-dom';
+import { Switch, Route } from 'react-router-dom';
 import Login from './pages/Login';
 import Dashboard from './pages/Dashboard';
 import Activities from './pages/Activities';
@@ -11,10 +11,11 @@ import VisitorDetails from './pages/VisitorDetails';
 import VisitsData from './pages/VisitsData';
 import Settings from './pages/Settings';
 import Feedback from './pages/Feedback';
+import NotFound from '../shared/components/NotFound';
 
 
 export default () => (
-  <>
+  <Switch>
     <Route exact path="/cb/password/reset/:token" component={ResetPassword} />
     <Route exact path="/cb/password/forgot" component={ForgotPassword} />
     <Route exact path="/cb/login" component={Login} />
@@ -26,5 +27,6 @@ export default () => (
     <Route exact path="/cb/visitors/:id" component={Visitor} />
     <Route exact path="/cb/settings" component={Settings} />
     <Route exact path="/cb/feedback" component={Feedback} />
-  </>
+    <Route component={NotFound} />
+  </Switch>
 );

--- a/src/visitors/index.js
+++ b/src/visitors/index.js
@@ -1,5 +1,5 @@
-import React, { Fragment } from 'react';
-import { Route } from 'react-router-dom';
+import React from 'react';
+import { Switch, Route } from 'react-router-dom';
 import Home from './pages/homeVisitor';
 import Signup from './pages/Signup';
 import Thanks from './pages/thanks';
@@ -7,15 +7,17 @@ import ThanksFeedback from './pages/thank_you_feedback';
 import QrError from './pages/qrerror';
 import Login from './pages/qrcode';
 import redirectAfterTimeout from '../shared/components/hoc/redirect_after_timeout';
+import NotFound from '../shared/components/NotFound';
 
 
 export default () => (
-  <Fragment>
+  <Switch>
     <Route exact path="/visitor/home" component={Home} />
     <Route path="/visitor/signup" component={Signup} />
     <Route exact path="/visitor/login" component={Login} />
     <Route exact path="/visitor/qrerror" component={QrError} />
     <Route exact path="/visitor/end" component={redirectAfterTimeout('/visitor/home', 5000)(Thanks)} />
     <Route exact path="/visitor/thankyou" component={redirectAfterTimeout('/visitor/home', 5000)(ThanksFeedback)} />
-  </Fragment>
+    <Route component={NotFound} />
+  </Switch>
 );


### PR DESCRIPTION


Fixes #637 

#### Changes
* nested routes use switch statement so they can return 404 if no matching page is found

#### User testing flows:

- [x] `/cb/does-not-exist` returns 404 page
- [x] `/visitor/does-not-exist` returns 404 page