### PR TITLE
💫 allow email or phone number to be unique identifier

### DIFF
--- a/src/visitors/components/signup_form.js
+++ b/src/visitors/components/signup_form.js
@@ -81,11 +81,10 @@ const signupForm = (props) => {
               name={`email$${props.uuid}`}
               type="email"
               error={props.errors.formEmail}
-              required
             />
             <LabelledInput
               id="visitor-signup-phonenumber"
-              label="Phone Number (optional)"
+              label="Phone Number"
               name={`phone$${props.uuid}`}
               type="text"
               error={props.errors.formPhone}

--- a/src/visitors/pages/Signup.js
+++ b/src/visitors/pages/Signup.js
@@ -106,9 +106,7 @@ export default class Main extends Component {
       organisationId: null,
       cbLogoUrl: '',
       formAutocompleteUUID: '', // See header comment in visitors/components/signup_form
-      /*
-       * last two values used as form validation for age
-       */
+      // form validation for age
       hasGivenAge: true, // defaults to true to avoid showing age checkbox on load
       ageCheck: false,
     };
@@ -164,6 +162,10 @@ export default class Main extends Component {
 
   createVisitor = (e) => {
     e.preventDefault();
+
+    if (!this.state.phone || !this.state.email) {
+      return this.setState({ errors: { formEmail: 'You must supply a phone number or email address' } });
+    }
 
     if (!this.state.hasGivenAge && !this.state.ageCheck) {
       return this.setState({ errors: { ageCheck: 'You must be over 13 to register' } });

--- a/src/visitors/pages/Signup.js
+++ b/src/visitors/pages/Signup.js
@@ -163,7 +163,7 @@ export default class Main extends Component {
   createVisitor = (e) => {
     e.preventDefault();
 
-    if (!this.state.phone || !this.state.email) {
+    if (!this.state.phone && !this.state.email) {
       return this.setState({ errors: { formEmail: 'You must supply a phone number or email address' } });
     }
 

--- a/src/visitors/pages/__tests__/Signup.test.js
+++ b/src/visitors/pages/__tests__/Signup.test.js
@@ -51,8 +51,11 @@ describe('Visitor Registration Component', () => {
 
     const tools = renderWithRouter({ route: '/visitor/signup' })(main);
 
+    // wait page to be ready by waiting for gender list to be populated
+    await waitForElement(() => tools.getByText('female', { exact: false }));
+
     const [
-      fullName,
+      fullname,
       email,
       phoneNumber,
       gender,
@@ -62,30 +65,60 @@ describe('Visitor Registration Component', () => {
     ] = await waitForElement(() => [
       tools.getByLabelText('Full Name'),
       tools.getByLabelText('Email Address'),
-      tools.getByLabelText('Phone Number (optional)'),
+      tools.getByLabelText('Phone Number'),
       tools.getByLabelText('Gender'),
       tools.getByLabelText('Year of Birth'),
       tools.getByTestId('emailConsent'),
       tools.getByText('CONTINUE'),
     ]);
 
-    fullName.value = visitor.name;
-    email.value = visitor.email;
-    phoneNumber.value = visitor.phoneNumber;
-    gender.value = visitor.gender;
-    birthYear.value = visitor.birthYear;
-    emailConsent.value = visitor.emailConsent;
-
-    fireEvent.change(fullName);
-    fireEvent.change(email);
-    fireEvent.change(phoneNumber);
-    fireEvent.change(gender);
-    fireEvent.change(birthYear);
-    fireEvent.change(emailConsent);
+    fireEvent.change(fullname, { target: { value: visitor.name } });
+    fireEvent.change(email, { target: { value: visitor.email } });
+    fireEvent.change(phoneNumber, { target: { value: visitor.phoneNumber } });
+    fireEvent.change(gender, { target: { value: visitor.gender } });
+    fireEvent.change(birthYear, { target: { value: visitor.birthYear } });
+    fireEvent.change(emailConsent, { target: { value: visitor.emailConsent } });
     fireEvent.click(submit);
 
     await wait(() => {
       expect(tools.history.location.pathname).toBe('/visitor/signup/thankyou');
     });
+  });
+
+  test('submit form w/o email or phone number', async () => {
+    expect.assertions(1);
+
+    mock
+      .onPost('/users/login/de-escalate')
+      .reply(200, { data: null });
+
+    mock
+      .onGet('/genders')
+      .reply(200, { result: [{ id: 1, name: 'male' }, { id: 2, name: 'female' }, { id: 3, name: 'prefer not to say' }] });
+
+    const tools = renderWithRouter({ route: '/visitor/signup' })(main);
+
+    // wait page to be ready by waiting for gender list to be populated
+    await waitForElement(() => tools.getByText('female', { exact: false }));
+
+    const [
+      fullname,
+      gender,
+      birthYear,
+      submit,
+    ] = await waitForElement(() => [
+      tools.getByLabelText('Full Name'),
+      tools.getByLabelText('Gender'),
+      tools.getByLabelText('Year of Birth'),
+      tools.getByText('CONTINUE'),
+    ]);
+
+    fireEvent.change(fullname, { target: { value: 'Sheva Alomar' } });
+    fireEvent.change(gender, { target: { value: 'female' } });
+    fireEvent.change(birthYear, { target: { value: '1988' } });
+    fireEvent.click(submit);
+
+    const error = await waitForElement(() => tools.getByText('supply', { exact: false }));
+    expect(error.textContent).toBe('You must supply a phone number or email address');
   });
 });

--- a/src/visitors/pages/__tests__/Signup.test.js
+++ b/src/visitors/pages/__tests__/Signup.test.js
@@ -19,7 +19,7 @@ describe('Visitor Registration Component', () => {
 
   afterEach(cleanup);
 
-  test('submit form w/ correct payload renders QR code', async () => {
+  test('submit form w/ email & phone number payload renders QR code', async () => {
     expect.assertions(1);
 
     const visitor = {
@@ -28,6 +28,138 @@ describe('Visitor Registration Component', () => {
       gender: 'female',
       birthYear: 1988,
       email: 'jvizzle@umbrellacorp.com',
+      phoneNumber: '+447777777777',
+      postCode: 'SG33 6JD',
+      emailConsent: true,
+      smsConsent: false,
+      qrCode: 'data:image/png;base64,329t4ji3nfp23nfergj42finoregn',
+    };
+
+    mock
+      .onPost('/users/login/de-escalate')
+      .reply(200, { data: null });
+
+    mock.onPost('/users/register/visitors').reply(200, { result: { ...visitor } })
+      .onGet('/community-businesses/me', { params: { fields: ['name', 'logoUrl', 'id'] } })
+      .reply(200, { result: { name: 'cbName', logoUrl: 'cbURL', id: 1 } })
+      .onGet('/users/me')
+      .reply(200, { result: {} });
+
+    mock
+      .onGet('/genders')
+      .reply(200, { result: [{ id: 1, name: 'male' }, { id: 2, name: 'female' }, { id: 3, name: 'prefer not to say' }] });
+
+    const tools = renderWithRouter({ route: '/visitor/signup' })(main);
+
+    // wait page to be ready by waiting for gender list to be populated
+    await waitForElement(() => tools.getByText('female', { exact: false }));
+
+    const [
+      fullname,
+      email,
+      phoneNumber,
+      gender,
+      birthYear,
+      emailConsent,
+      submit,
+    ] = await waitForElement(() => [
+      tools.getByLabelText('Full Name'),
+      tools.getByLabelText('Email Address'),
+      tools.getByLabelText('Phone Number'),
+      tools.getByLabelText('Gender'),
+      tools.getByLabelText('Year of Birth'),
+      tools.getByTestId('emailConsent'),
+      tools.getByText('CONTINUE'),
+    ]);
+
+    fireEvent.change(fullname, { target: { value: visitor.name } });
+    fireEvent.change(email, { target: { value: visitor.email } });
+    fireEvent.change(phoneNumber, { target: { value: visitor.phoneNumber } });
+    fireEvent.change(gender, { target: { value: visitor.gender } });
+    fireEvent.change(birthYear, { target: { value: visitor.birthYear } });
+    fireEvent.change(emailConsent, { target: { value: visitor.emailConsent } });
+    fireEvent.click(submit);
+
+    await wait(() => {
+      expect(tools.history.location.pathname).toBe('/visitor/signup/thankyou');
+    });
+  });
+
+  test('submit form w/ email payload renders QR code', async () => {
+    expect.assertions(1);
+
+    const visitor = {
+      id: 1,
+      name: 'Jill Valentine',
+      gender: 'female',
+      birthYear: 1988,
+      email: 'jvizzle@umbrellacorp.com',
+      phoneNumber: '',
+      postCode: 'SG33 6JD',
+      emailConsent: true,
+      smsConsent: false,
+      qrCode: 'data:image/png;base64,329t4ji3nfp23nfergj42finoregn',
+    };
+
+    mock
+      .onPost('/users/login/de-escalate')
+      .reply(200, { data: null });
+
+    mock.onPost('/users/register/visitors').reply(200, { result: { ...visitor } })
+      .onGet('/community-businesses/me', { params: { fields: ['name', 'logoUrl', 'id'] } })
+      .reply(200, { result: { name: 'cbName', logoUrl: 'cbURL', id: 1 } })
+      .onGet('/users/me')
+      .reply(200, { result: {} });
+
+    mock
+      .onGet('/genders')
+      .reply(200, { result: [{ id: 1, name: 'male' }, { id: 2, name: 'female' }, { id: 3, name: 'prefer not to say' }] });
+
+    const tools = renderWithRouter({ route: '/visitor/signup' })(main);
+
+    // wait page to be ready by waiting for gender list to be populated
+    await waitForElement(() => tools.getByText('female', { exact: false }));
+
+    const [
+      fullname,
+      email,
+      phoneNumber,
+      gender,
+      birthYear,
+      emailConsent,
+      submit,
+    ] = await waitForElement(() => [
+      tools.getByLabelText('Full Name'),
+      tools.getByLabelText('Email Address'),
+      tools.getByLabelText('Phone Number'),
+      tools.getByLabelText('Gender'),
+      tools.getByLabelText('Year of Birth'),
+      tools.getByTestId('emailConsent'),
+      tools.getByText('CONTINUE'),
+    ]);
+
+    fireEvent.change(fullname, { target: { value: visitor.name } });
+    fireEvent.change(email, { target: { value: visitor.email } });
+    fireEvent.change(phoneNumber, { target: { value: visitor.phoneNumber } });
+    fireEvent.change(gender, { target: { value: visitor.gender } });
+    fireEvent.change(birthYear, { target: { value: visitor.birthYear } });
+    fireEvent.change(emailConsent, { target: { value: visitor.emailConsent } });
+    fireEvent.click(submit);
+
+    await wait(() => {
+      expect(tools.history.location.pathname).toBe('/visitor/signup/thankyou');
+    });
+  });
+
+  test('submit form w/ phone number payload renders QR code', async () => {
+    expect.assertions(1);
+
+    const visitor = {
+      id: 1,
+      name: 'Jill Valentine',
+      gender: 'female',
+      birthYear: 1988,
+      email: '',
       phoneNumber: '+447777777777',
       postCode: 'SG33 6JD',
       emailConsent: true,


### PR DESCRIPTION
💫 allow email or phone number to be unique identifier

- update validation to check one or the other is supplied
- remove required from email input box
- add tests for various signup flows

Fixes #645

Related to #647

Partnered PR: TwinePlatform/twine-api#318

UI TESTS:
- signup with only email
- signup with only phone number