### PR TITLE
💄 Styling fixes & prop bug fix

### DIFF
--- a/src/cb_admin/components/DetailsTable.js
+++ b/src/cb_admin/components/DetailsTable.js
@@ -9,9 +9,10 @@ const Table = styled.table`
   background-color: ${colors.highlight_secondary}; /* Fallback */
   background: linear-gradient(0, ${rgba(colors.highlight_secondary, 0.75)} 0%, ${colors.highlight_secondary} 100%);
   color: ${colors.white};
-  width: 90%;
-  height: 6em;
-  padding: 2em;
+  height: 98%;
+  width: 100%;
+  padding: 1.5em 2em 1.5em 1em;
+  word-break: break-word;
 `;
 const TableCaption = styled.caption`
   display: none;

--- a/src/cb_admin/components/Dropzone.js
+++ b/src/cb_admin/components/Dropzone.js
@@ -12,8 +12,7 @@ const StyledDropzone = styled(Dropzone) `
   flex-direction: column;
   justify-content: center;
   height: 8em;
-  width: 90%;
-  margin: 1.2em 0 2em 0;
+  margin: 1.2em 0 1.5em 0;
   border: 0.1em dashed ${colors.light};
   border-radius: 0;
   background-color: ${rgba(colors.highlight_primary, 0.06)};
@@ -37,7 +36,9 @@ const DropZone = props => (
     onDrop={props.onDrop}
   >
     <UploadIcon alt="upload icon" src={uploadSvg} />
-    { props.content }
+    <span style={{ padding: '0 0.2em' }}>
+      { props.content }
+    </span>
   </StyledDropzone>
 );
 

--- a/src/cb_admin/components/Logo.js
+++ b/src/cb_admin/components/Logo.js
@@ -2,10 +2,9 @@ import React from 'react';
 import styled from 'styled-components';
 
 const Img = styled.img`
-  height: 11em;
-  width: 90%;
   object-fit: contain;
   object-position: center;
+  max-width: 100%;
 `;
 
 export default props => <Img {...props} />;

--- a/src/cb_admin/components/QrBox.js
+++ b/src/cb_admin/components/QrBox.js
@@ -6,16 +6,13 @@ import { fonts, colors } from '../../shared/style_guide';
 
 
 const Container = styled.div`
-  height: 11em;
-  width: 90%;
 `;
 
 const Img = styled.img`
-  height: 11em;
-  width: 50%;
   object-fit: contain;
   object-position: center;
   display: block;
+  margin: auto;
 `;
 
 const Button = styled(PrimaryButton) `

--- a/src/cb_admin/pages/Activities.js
+++ b/src/cb_admin/pages/Activities.js
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { assocPath, dissoc, invertObj } from 'ramda';
+import { Grid, Row, Col } from 'react-flexbox-grid';
 import { FlexContainerCol } from '../../shared/components/layout/base';
 import { Paragraph, ErrorParagraph } from '../../shared/components/text/base';
 import { Form, PrimaryButton } from '../../shared/components/form/base';
@@ -18,6 +19,7 @@ const SubmitButton = styled(PrimaryButton) `
   margin-left: 2em;
   height: 3em;
 `;
+
 
 const ActivitiesError = styled(ErrorParagraph) `
   opacity: ${props => (props.vis ? '1' : '0')};
@@ -169,25 +171,35 @@ export default class ActivitiesPage extends React.Component {
           to your visitors, and just deselect all days if the one you are editing is a one-off
           event or not currently on the agenda.
         </Paragraph>
-        <Form onSubmit={this.addActivity} onChange={this.onChange}>
-          <LabelledInput
-            id="cb-admin-activities-name"
-            label="Add an activity"
-            name="name"
-            type="text"
-            error={errors.activity}
-            required
-          />
-          <LabelledSelect
-            id="cb-admin-activities-category"
-            label="Category"
-            name="category"
-            options={this.state.categories}
-            error={errors.activity}
-            required
-          />
-          <SubmitButton type="submit">ADD</SubmitButton>
-        </Form>
+        <Grid>
+          <Form onSubmit={this.addActivity} onChange={this.onChange}>
+            <Row middle="xs" around="xs">
+              <Col md={5}>
+                <LabelledInput
+                  id="cb-admin-activities-name"
+                  label="Add an activity"
+                  name="name"
+                  type="text"
+                  error={errors.activity}
+                  required
+                />
+              </Col>
+              <Col md={5}>
+                <LabelledSelect
+                  id="cb-admin-activities-category"
+                  label="Category"
+                  name="category"
+                  options={this.state.categories}
+                  error={errors.activity}
+                  required
+                />
+              </Col>
+              <Col md={2}>
+                <SubmitButton type="submit">ADD</SubmitButton>
+              </Col>
+            </Row>
+          </Form>
+        </Grid>
         {errorMessage}
         <Table>
           <TableHead>

--- a/src/cb_admin/pages/ConfirmPassword.js
+++ b/src/cb_admin/pages/ConfirmPassword.js
@@ -11,11 +11,10 @@ import NavHeader from '../../shared/components/NavHeader';
 
 const SubmitButton = styled(PrimaryButton) `
   height: 4em;
-  width: 90%;
+  width: 100%;
 `;
 
 const CenteredParagraph = styled(Paragraph) `
-  /* width: 90%; */
   text-align: center;
   margin: 2em 0;
 `;
@@ -64,7 +63,7 @@ export default class ConfirmPassword extends React.Component {
               required
             />
             <SubmitButton>CONTINUE</SubmitButton>
-            <div style={{ textAlign: 'center', margin: '2em 0', width: '90%' }}>
+            <div style={{ textAlign: 'center', margin: '2em 0' }}>
               <Link to="/cb/password/forgot">Forgot password?</Link>
             </div>
           </FormSection>

--- a/src/cb_admin/pages/ForgotPassword.js
+++ b/src/cb_admin/pages/ForgotPassword.js
@@ -11,11 +11,11 @@ import { redirectOnError } from '../../util';
 
 const SubmitButton = styled(PrimaryButton) `
   height: 4em;
-  width: 90%;
+  width: 100%;
 `;
 
 const CenteredParagraph = styled(Paragraph)`
-  width: 90%;
+  width: 100%;
   text-align: center;
   margin: 2em 0;
 `;
@@ -67,7 +67,7 @@ export default class ForgotPassword extends React.Component {
               required
             />
             <SubmitButton>CONTINUE</SubmitButton>
-            <div style={{ textAlign: 'center', margin: '2em 0', width: '90%' }}>
+            <div style={{ textAlign: 'center', margin: '2em 0', width: '100%' }}>
               <Link to="/cb/login">Back to login</Link>
             </div>
           </FormSection>

--- a/src/cb_admin/pages/Login.js
+++ b/src/cb_admin/pages/Login.js
@@ -12,7 +12,7 @@ import { redirectOnError } from '../../util';
 
 const SubmitButton = styled(PrimaryButton)`
   height: 4em;
-  width: 90%;
+  width: 100%;
 `;
 
 const CenteredParagraph = styled(Paragraph)`

--- a/src/cb_admin/pages/ResetPassword.js
+++ b/src/cb_admin/pages/ResetPassword.js
@@ -16,7 +16,7 @@ const payloadFromState = pick(['password', 'passwordConfirm']);
 
 const SubmitButton = styled(PrimaryButton) `
   height: 4em;
-  width: 90%;
+  width: 100%;
 `;
 
 const ErrorText = styled.p`

--- a/src/cb_admin/pages/Settings.js
+++ b/src/cb_admin/pages/Settings.js
@@ -23,6 +23,7 @@ import NavHeader from '../../shared/components/NavHeader';
 const FlexItem = styled.div`
   flex: ${props => props.flex || '1'};
   height: 100%;
+  margin-right: 1em;
 `;
 
 const Form = styled(Fm)`

--- a/src/cb_admin/pages/Settings.js
+++ b/src/cb_admin/pages/Settings.js
@@ -6,7 +6,7 @@ import { assocPath, compose, pick, prop, filter, pipe, prepend, map, omit, flatt
 import csv from 'fast-csv';
 import jsZip from 'jszip';
 import fileSaver from 'file-saver';
-import { FlexContainerCol, FlexContainerRow } from '../../shared/components/layout/base';
+import { Grid, Row, Col } from 'react-flexbox-grid';
 import { Paragraph as P } from '../../shared/components/text/base';
 import { Form as Fm, PrimaryButton } from '../../shared/components/form/base';
 import LabelledInput from '../../shared/components/form/LabelledInput';
@@ -20,12 +20,6 @@ import { renameKeys, redirectOnError } from '../../util';
 import NavHeader from '../../shared/components/NavHeader';
 
 
-const FlexItem = styled.div`
-  flex: ${props => props.flex || '1'};
-  height: 100%;
-  margin-right: 1em;
-`;
-
 const Form = styled(Fm)`
   width: 100%;
 `;
@@ -34,27 +28,20 @@ const Paragraph = styled(P)`
   width: 100%;
 `;
 
-const Row = styled(FlexContainerRow)`
-  align-content: center;
-  align-items: flex-start;
-  flex: 2;
-  margin-bottom: 1.5em;
-`;
-
 const Button = styled(PrimaryButton)`
-  width: 90%;
+  width: 100%;
   height: 3em;
 `;
 
 const ExportButton = styled(Button)`
-  width: 50%;
+  width: 100%;
 `;
 
 const ErrorMessage = styled(P)`
   color: ${colors.error};
   display: inline-block;
   height: 3em;
-  width: 50%;
+  width: 100%;
   padding: 1rem;
 `;
 
@@ -259,24 +246,24 @@ export default class SettingsPage extends React.Component {
     ];
 
     return (
-      <FlexContainerCol>
+      <Grid>
         <NavHeader
           leftTo="/cb/dashboard"
           leftContent="Back to dashboard"
           centerContent={rest.name}
         />
-        <Row>
-          <FlexItem flex={7}>
+        <Row between="xs">
+          <Col xs={12} md={7}>
             <DetailsTable rows={rows} caption="Business details" />
-          </FlexItem>
-          <FlexItem flex={4}>
+          </Col>
+          <Col xs={12} md={4}>
             <Logo src={rest.logoUrl} alt="Business logo" />
-          </FlexItem>
+          </Col>
         </Row>
-        <FlexContainerRow flex={4}>
-          <Form onChange={this.onChange} onSubmit={this.onSubmit}>
-            <Paragraph>Edit your details</Paragraph>
-            <FlexItem flex={7}>
+        <Paragraph>Edit your details</Paragraph>
+        <Form onChange={this.onChange} onSubmit={this.onSubmit}>
+          <Row between="xs">
+            <Col xs={12} md={7}>
               <LabelledInput
                 id="cb-admin-business-name"
                 label="Business name"
@@ -304,18 +291,17 @@ export default class SettingsPage extends React.Component {
               />
               <ExportButton type="button" onClick={this.createZip}>Download data as CSV</ExportButton>
               <ErrorMessage>{this.state.errors.general}</ErrorMessage>
-            </FlexItem>
-            <FlexItem flex={4}>
+            </Col>
+            <Col xs={12} md={4}>
               <Dropzone
                 content={rest.dropzoneMsg}
-                disabled={Boolean(rest.logoUrl)}
                 onDrop={this.onImageDrop}
               />
               <Button type="submit">SAVE</Button>
-            </FlexItem>
-          </Form>
-        </FlexContainerRow>
-      </FlexContainerCol>
+            </Col>
+          </Row>
+        </Form>
+      </Grid>
     );
   }
 }

--- a/src/cb_admin/pages/Settings.js
+++ b/src/cb_admin/pages/Settings.js
@@ -6,9 +6,9 @@ import { assocPath, compose, pick, prop, filter, pipe, prepend, map, omit, flatt
 import csv from 'fast-csv';
 import jsZip from 'jszip';
 import fileSaver from 'file-saver';
-import { Grid, Row, Col } from 'react-flexbox-grid';
+import { Grid, Row as RW, Col } from 'react-flexbox-grid';
 import { Paragraph as P } from '../../shared/components/text/base';
-import { Form as Fm, PrimaryButton } from '../../shared/components/form/base';
+import { PrimaryButton } from '../../shared/components/form/base';
 import LabelledInput from '../../shared/components/form/LabelledInput';
 import LabelledSelect from '../../shared/components/form/LabelledSelect';
 import { colors } from '../../shared/style_guide';
@@ -20,7 +20,11 @@ import { renameKeys, redirectOnError } from '../../util';
 import NavHeader from '../../shared/components/NavHeader';
 
 
-const Form = styled(Fm)`
+const Row = styled(RW)`
+  width: 100%;
+`;
+
+const Form = styled.form`
   width: 100%;
 `;
 

--- a/src/cb_admin/pages/Visitor.js
+++ b/src/cb_admin/pages/Visitor.js
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import moment from 'moment';
 import { assocPath, compose, filter, pick, prop } from 'ramda';
 import { Grid as Gr, Row, Col } from 'react-flexbox-grid';
-import { FlexContainerCol, FlexContainerRow } from '../../shared/components/layout/base';
+import { FlexContainerRow } from '../../shared/components/layout/base';
 import { Paragraph as P, Heading } from '../../shared/components/text/base';
 import { Form as Fm, PrimaryButton } from '../../shared/components/form/base';
 import LabelledInput from '../../shared/components/form/LabelledInput';
@@ -23,12 +23,6 @@ const Grid = styled(Gr) `
   }
 `;
 
-// const FlexItem = styled.div`
-//   flex: ${props => props.flex || '1'};
-//   height: 100%;
-//   margin-right: 1em;
-// `;
-
 const Form = styled(Fm) `
   width: 100%;
 `;
@@ -36,12 +30,6 @@ const Form = styled(Fm) `
 const Paragraph = styled(P) `
   width: 100%;
 `;
-
-// const Row = styled(FlexContainerRow) `
-//   align-content: center;
-//   align-items: flex-start;
-//   flex: 3;
-// `;
 
 const Button = styled(PrimaryButton) `
   width: 100%;

--- a/src/cb_admin/pages/Visitor.js
+++ b/src/cb_admin/pages/Visitor.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import moment from 'moment';
 import { assocPath, compose, filter, pick, prop } from 'ramda';
+import { Grid as Gr, Row, Col } from 'react-flexbox-grid';
 import { FlexContainerCol, FlexContainerRow } from '../../shared/components/layout/base';
 import { Paragraph as P, Heading } from '../../shared/components/text/base';
 import { Form as Fm, PrimaryButton } from '../../shared/components/form/base';
@@ -16,17 +17,17 @@ import p2cLogo from '../../shared/assets/images/qrcodelogo.png';
 import { renameKeys, redirectOnError } from '../../util';
 import { BirthYear } from '../../shared/constants';
 
-const Col = styled(FlexContainerCol) `
+const Grid = styled(Gr) `
   @media print {
     display: none;
   }
 `;
 
-const FlexItem = styled.div`
-  flex: ${props => props.flex || '1'};
-  height: 100%;
-  margin-right: 1em;
-`;
+// const FlexItem = styled.div`
+//   flex: ${props => props.flex || '1'};
+//   height: 100%;
+//   margin-right: 1em;
+// `;
 
 const Form = styled(Fm) `
   width: 100%;
@@ -36,11 +37,11 @@ const Paragraph = styled(P) `
   width: 100%;
 `;
 
-const Row = styled(FlexContainerRow) `
-  align-content: center;
-  align-items: flex-start;
-  flex: 3;
-`;
+// const Row = styled(FlexContainerRow) `
+//   align-content: center;
+//   align-items: flex-start;
+//   flex: 3;
+// `;
 
 const Button = styled(PrimaryButton) `
   width: 100%;
@@ -201,17 +202,17 @@ export default class VisitorProfile extends React.Component {
     ];
 
     return (
-      <Col>
+      <Grid>
         <NavHeader
           leftTo="/cb/dashboard"
           leftContent="Back to dashboard"
           centerContent="Visitor profile"
         />
-        <Row>
-          <FlexItem flex={7}>
+        <Row between="xs">
+          <Col xs={12} md={7}>
             <DetailsTable rows={rows} caption="Visitor details" />
-          </FlexItem>
-          <FlexItem flex={4}>
+          </Col>
+          <Col xs={12} md={4}>
             <QrBox
               qrCodeUrl={rest.qrCodeUrl}
               print={this.onClickPrint}
@@ -219,12 +220,12 @@ export default class VisitorProfile extends React.Component {
               status={rest.resendQrCodeState}
               error={errors.resendButton}
             />
-          </FlexItem>
+          </Col>
         </Row>
-        <FlexContainerRow flex={4}>
-          <Form onChange={this.onChange} onSubmit={this.onSubmit}>
-            <Paragraph>Edit user details</Paragraph>
-            <FlexItem flex={7}>
+        <Paragraph>Edit user details</Paragraph>
+        <Form onChange={this.onChange} onSubmit={this.onSubmit}>
+          <Row between="xs" style={{ width: '100%' }}>
+            <Col xs={12} md={7}>
               <LabelledInput
                 id="visitor-name"
                 label="Name"
@@ -242,8 +243,8 @@ export default class VisitorProfile extends React.Component {
                 error={errors.email}
               />
               <Button type="submit">SAVE</Button>
-            </FlexItem>
-            <FlexItem flex={4}>
+            </Col>
+            <Col xs={12} md={4}>
               <LabelledSelect
                 id="visitor-birthYear"
                 label="Year of birth"
@@ -260,10 +261,10 @@ export default class VisitorProfile extends React.Component {
                 value={rest.form.gender || rest.gender}
                 error={errors.gender}
               />
-            </FlexItem>
-          </Form>
-        </FlexContainerRow>
-      </Col>
+            </Col>
+          </Row>
+        </Form>
+      </Grid>
     );
   }
 

--- a/src/cb_admin/pages/Visitor.js
+++ b/src/cb_admin/pages/Visitor.js
@@ -25,6 +25,7 @@ const Col = styled(FlexContainerCol) `
 const FlexItem = styled.div`
   flex: ${props => props.flex || '1'};
   height: 100%;
+  margin-right: 1em;
 `;
 
 const Form = styled(Fm) `
@@ -42,7 +43,7 @@ const Row = styled(FlexContainerRow) `
 `;
 
 const Button = styled(PrimaryButton) `
-  width: 90%;
+  width: 100%;
   height: 3em;
 `;
 

--- a/src/cb_admin/pages/VisitorDetails.js
+++ b/src/cb_admin/pages/VisitorDetails.js
@@ -30,6 +30,7 @@ const Row = styled(FlexContainerRow)`
 
 const FormSection = styled.section`
   width: 20%;
+  margin: 0 0.5em;
 `;
 
 const ExportButton = styled(PrimaryButton)`

--- a/src/shared/components/NavHeader.js
+++ b/src/shared/components/NavHeader.js
@@ -17,7 +17,7 @@ const NavHeaderItem = ({ to, content, onClick }) => (
     ? <HyperLink to={to} onClick={onClick}>{content}</HyperLink>
     : typeof content === 'string'
       ? <Heading onClick={onClick}>{content}</Heading>
-      : <Fragment onClick={onClick}>{content}</Fragment>
+      : <Fragment>{content}</Fragment>
 );
 
 NavHeaderItem.propTypes = {
@@ -81,9 +81,6 @@ NavHeader.defaultProps = {
   leftOnClick: noop,
   centreOnClick: noop,
   rightOnClick: noop,
-  leftCol: { sm: 1, md: 1, lg: 1 },
-  centerCol: { sm: 1, md: 1, lg: 1 },
-  rightCol: { sm: 1, md: 1, lg: 1 },
 };
 
 

--- a/src/shared/components/form/LabelledInput.js
+++ b/src/shared/components/form/LabelledInput.js
@@ -13,12 +13,16 @@ const ErrorText = styled.span`
   display: ${props => (props.show ? 'inline' : 'none')};
 `;
 
+const InputContainer = styled.div`
+  width: 100%;
+`;
+
 
 const LabelledInput = (props) => {
   const { id, label, error, ...rest } = props;
 
   return (
-    <div>
+    <InputContainer>
       <div>
         <Label htmlFor={id} display="inline">
           {[
@@ -29,7 +33,7 @@ const LabelledInput = (props) => {
         <ErrorText key={1} show={error}>{error}</ErrorText>
       </div>
       <Input id={id} {...rest} />
-    </div>
+    </InputContainer>
   );
 };
 

--- a/src/shared/components/form/LabelledSelect.js
+++ b/src/shared/components/form/LabelledSelect.js
@@ -12,6 +12,10 @@ color: ${colors.error};
 display: ${props => (props.show ? 'inline' : 'none')};
 `;
 
+const LabelledSelectContainer = styled.div`
+  width: 100%;
+`;
+
 const LabelledSelect = (props) => {
   const { id, label, options, error, ...rest } = props;
 
@@ -27,10 +31,9 @@ const LabelledSelect = (props) => {
 
 
   return (
-    <div>
-      <Label htmlFor={id} display={'inline'}>{label}</Label>
-      <ErrorText key={1} show={error}>{error}</ErrorText>
-
+    <LabelledSelectContainer>
+      <Label htmlFor={id}>{label}</Label>
+      <ErrorText show={error}>{error}</ErrorText>
       <SelectWrapper>
         <Select id={id} {...rest}>
           {options.map(opt => (
@@ -41,7 +44,7 @@ const LabelledSelect = (props) => {
         </Select>
         <SelectArrow />
       </SelectWrapper>
-    </div>
+    </LabelledSelectContainer>
   );
 };
 

--- a/src/shared/components/form/base.js
+++ b/src/shared/components/form/base.js
@@ -6,7 +6,7 @@ import { rgba } from 'polished';
 import { colors, fonts } from '../../style_guide';
 
 export const Input = styled.input`
-  width: 90%;
+  width: 100%;
   padding: 0.7em;
   border: 0.1em solid ${colors.light};
   border-radius: 0.15em;
@@ -36,7 +36,7 @@ export const Select = styled.select`
 `;
 
 export const SelectWrapper = styled.div`
-  width: 90%;
+  width: 100%;
   margin-bottom: 1em;
   padding: 0.6em;
   border: 0.1em solid ${colors.light};

--- a/src/shared/components/form/base.js
+++ b/src/shared/components/form/base.js
@@ -38,7 +38,7 @@ export const Select = styled.select`
 export const SelectWrapper = styled.div`
   width: 90%;
   margin-bottom: 1em;
-  padding: 0.7em;
+  padding: 0.6em;
   border: 0.1em solid ${colors.light};
   border-radius: 0.15em;
   overflow: hidden;

--- a/src/visitors/components/signup_form.js
+++ b/src/visitors/components/signup_form.js
@@ -23,7 +23,7 @@ import { VISITOR_NAME_INVALID } from '../../cb_admin/constants/error_text';
 
 const SubmitButton = styled(PrimaryButton)`
   height: 4em;
-  width: 90%;
+  width: 100%;
 `;
 
 const PrivacyLink = styled.a`

--- a/src/visitors/components/signup_form.js
+++ b/src/visitors/components/signup_form.js
@@ -11,7 +11,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Grid, Row } from 'react-flexbox-grid';
-import { Form, FormSection, PrimaryButton } from '../../shared/components/form/base';
+import { Form as FM, FormSection, PrimaryButton } from '../../shared/components/form/base';
 import { Paragraph } from '../../shared/components/text/base';
 import LabelledInput from '../../shared/components/form/LabelledInput';
 import StyledLabelledCheckbox from '../../shared/components/form/StyledLabelledCheckbox';
@@ -20,6 +20,11 @@ import { FlexContainerRow } from '../../shared/components/layout/base';
 import NavHeader from '../../shared/components/NavHeader';
 import { colors, fonts } from '../../shared/style_guide';
 import { VISITOR_NAME_INVALID } from '../../cb_admin/constants/error_text';
+
+
+const Form = styled(FM)`
+  align-items: baseline;
+`;
 
 const SubmitButton = styled(PrimaryButton)`
   height: 4em;
@@ -32,7 +37,6 @@ const PrivacyLink = styled.a`
 `;
 
 const CenteredParagraph = styled(Paragraph)`
-  width: 90%;
   line-height: 1.5em;
 `;
 
@@ -65,7 +69,7 @@ const signupForm = (props) => {
         centerContent="Please tell us about yourself"
       />
       <Row>
-        <Form className="SignupForm" onChange={props.handleChange} onSubmit={props.createVisitor}>
+        <Form onChange={props.handleChange} onSubmit={props.createVisitor}>
           <FormSection flexOrder={1}>
             <div>
               <LabelledInput


### PR DESCRIPTION
This is mainly to get away from the silly 90% thing we were
doing everywhere. Using 100% width and setting explicit margin
and padding is better, instead of having layouts implicitly depend
on elements not using the full width of their container.

* Make LabelledInput and LabelledSelect 100% width
* Reduce padding on LabelledSelect to improve alignment w LabelledInput
* Update several pages w/ Button width 90% -> 100%
* Add margin/padding to places that were relying on this 90% width thing

In addition, fix a bug with the newly introduced `NavHeader` component; `Fragment` elements are not allowed to have click handlers.