### PR TITLE
🐛 fix signup bug

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -2,7 +2,7 @@
  * Twine API interface
  */
 import _axios, { create } from 'axios';
-import { pathOr, equals, evolve, map } from 'ramda';
+import { pathOr, equals, evolve, map, filter } from 'ramda';
 import qs from 'qs';
 import { BirthYear } from '../shared/constants';
 
@@ -65,7 +65,7 @@ export const Visitors = {
   ) =>
     axios.post(
       '/users/register/visitors',
-      {
+      filter(Boolean, {
         name,
         gender,
         birthYear,
@@ -74,7 +74,7 @@ export const Visitors = {
         emailConsent,
         smsConsent,
         organisationId,
-      },
+      }),
     ),
 
   update: ({ id, name, gender, birthYear, email, phoneNumber } = {}) =>

--- a/src/visitors/components/signup_form.js
+++ b/src/visitors/components/signup_form.js
@@ -73,7 +73,7 @@ const signupForm = (props) => {
                 label="Full Name"
                 name={`fullname$${props.uuid}`}
                 type="text"
-                error={props.errors.formSender && VISITOR_NAME_INVALID}
+                error={props.errors.name && VISITOR_NAME_INVALID}
                 required
               />
               <LabelledInput
@@ -81,21 +81,21 @@ const signupForm = (props) => {
                 label="Email Address"
                 name={`email$${props.uuid}`}
                 type="email"
-                error={props.errors.formEmail}
+                error={props.errors.email}
               />
               <LabelledInput
                 id="visitor-signup-phonenumber"
                 label="Phone Number"
                 name={`phone$${props.uuid}`}
                 type="text"
-                error={props.errors.formPhone}
+                error={props.errors.number}
               />
               <LabelledSelect
                 id="visitor-signup-gender"
                 label="Gender"
                 name="gender"
                 options={props.genders}
-                error={props.errors.formGender}
+                error={props.errors.gender}
                 required
               />
               <LabelledSelect
@@ -103,7 +103,7 @@ const signupForm = (props) => {
                 label="Year of Birth"
                 name="year"
                 options={props.years}
-                error={props.errors.formYear}
+                error={props.errors.birthYear}
                 required
               />
               {!props.hasGivenAge && ageCheckCheckbox}

--- a/src/visitors/pages/Signup.js
+++ b/src/visitors/pages/Signup.js
@@ -164,7 +164,7 @@ export default class Main extends Component {
     e.preventDefault();
 
     if (!this.state.phone && !this.state.email) {
-      return this.setState({ errors: { formEmail: 'You must supply a phone number or email address' } });
+      return this.setState({ errors: { email: 'You must supply a phone number or email address' } });
     }
 
     if (!this.state.hasGivenAge && !this.state.ageCheck) {

--- a/src/visitors/pages/Signup.js
+++ b/src/visitors/pages/Signup.js
@@ -190,7 +190,7 @@ export default class Main extends Component {
           this.setState({ errors: ErrorUtils.getValidationErrors(err) });
         } else if (ErrorUtils.errorStatusEquals(err, 409)) {
           this.setState({
-            errors: { formEmail: 'A user has already been registered with this name and email' },
+            errors: { email: ErrorUtils.getErrorMessage(err) },
           });
         } else {
           redirectOnError(this.props.history.push, err);


### PR DESCRIPTION
discovered in review #656


#### Changes
- do not send empty values in signup flow
- render correct error messages

User flow:
- sign up with only email
- signup with only phone number

Partnered PR: TwinePlatform/twine-api#326
