### PR TITLE
🚀 DEPLOYMENT 06-03-19

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -77,7 +77,16 @@ export const Visitors = {
       }),
     ),
 
-  update: ({ id, name, gender, birthYear, email, phoneNumber } = {}) =>
+  update: ({
+    id,
+    name,
+    gender,
+    birthYear,
+    email,
+    phoneNumber,
+    isEmailConsentGranted,
+    isSMSConsentGranted,
+  } = {}) =>
     axios.put(
       `/community-businesses/me/visitors/${id}`,
       {
@@ -86,6 +95,8 @@ export const Visitors = {
         email,
         phoneNumber,
         birthYear,
+        isEmailConsentGranted,
+        isSMSConsentGranted,
       },
     ),
 

--- a/src/cb_admin/components/QrBox.js
+++ b/src/cb_admin/components/QrBox.js
@@ -1,12 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { Grid, Row } from 'react-flexbox-grid';
 import { PrimaryButton } from '../../shared/components/form/base';
 import { fonts, colors } from '../../shared/style_guide';
 
-
-const Container = styled.div`
-`;
 
 const Img = styled.img`
   object-fit: contain;
@@ -17,7 +15,6 @@ const Img = styled.img`
 
 const Button = styled(PrimaryButton) `
   width: 45%;
-  margin: 0 2.5%;
   height: 4.5em;
   font-size: ${fonts.size.small};
 `;
@@ -37,18 +34,21 @@ const QrBox = ({ qrCodeUrl, print, send, error, status }) => {
   const hasError = status === resendQrCodeState.ERROR;
 
   return (
-    <Container>
+    <Grid>
       <Img alt="QR code" src={qrCodeUrl} />
-      <Button onClick={print}>PRINT QR CODE</Button>
-      <Button onClick={send} disabled={hasSent}>
-        {
-          hasSent
-            ? 'QR CODE SENT'
-            : 'RESEND QR CODE'
-        }
-      </Button>
+      <Row between={'xs'}>
+        <Button onClick={print}>PRINT QR CODE</Button>
+        <Button onClick={send} disabled={hasSent}>
+          {
+            hasSent
+              ? 'QR CODE SENT'
+              : 'RESEND QR CODE'
+          }
+        </Button>
+
+      </Row>
       {hasError && <ErrorText>{error.message}</ErrorText>}
-    </Container>
+    </Grid>
   );
 };
 

--- a/src/cb_admin/pages/__tests__/Visitor.test.js
+++ b/src/cb_admin/pages/__tests__/Visitor.test.js
@@ -102,7 +102,7 @@ describe('Visitor Component', () => {
   });
 
   test(':: can update visitor details', async () => {
-    expect.assertions(3);
+    expect.assertions(4);
 
     mock.onPut('/community-businesses/me')
       .reply(200, { result: null });
@@ -160,16 +160,24 @@ describe('Visitor Component', () => {
     // ensures page has successfully loaded before continuing with tests
     await waitForElement(() => tools.getByText('yusra mardini'));
 
-    const [nameInput, emailInput, genderInput, submitBtn] = await waitForElement(() => [
+    const [
+      nameInput,
+      emailInput,
+      genderInput,
+      emailConsentBox,
+      submitBtn,
+    ] = await waitForElement(() => [
       tools.getByLabelText('Name'),
       tools.getByLabelText('Email'),
       tools.getByLabelText('Gender'),
+      tools.container.querySelector('#visitor-email-consent'),
       tools.getByText('SAVE'),
     ]);
 
     fireEvent.change(nameInput, { target: { value: 'foosra mardini' } });
     fireEvent.change(emailInput, { target: { value: 'manewmail@gmail.com' } });
     fireEvent.change(genderInput, { target: { value: 'male' } });
+    fireEvent.change(emailConsentBox, { target: { value: 'on' } });
     fireEvent.click(submitBtn);
 
     const [nameText, emailText, genderText] = await waitForElement(() => [
@@ -181,6 +189,7 @@ describe('Visitor Component', () => {
     expect(nameText).toBeTruthy();
     expect(emailText).toBeTruthy();
     expect(genderText).toBeTruthy();
+    expect(emailConsentBox.value).toBe('on');
   });
 
   test(':: fail to update visitor details', async () => {

--- a/src/shared/components/form/Checkbox.js
+++ b/src/shared/components/form/Checkbox.js
@@ -1,0 +1,64 @@
+/*
+ * Custom-styled checkbox
+ *
+ * Adapted from:
+ * https://medium.com/@colebemis/building-a-checkbox-component-with-react-and-styled-components-8d3aa1d826dd
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { hideVisually } from 'polished';
+import { colors } from '../../style_guide';
+
+
+const HiddenCheckbox = styled.input.attrs({ type: 'checkbox' })`
+  ${hideVisually()}
+`;
+
+const StyledCheckbox = styled.div`
+  display: inline-block;
+  width: 2rem;
+  height: 2rem;
+  background: ${props => props.checked ? colors.highlight_primary : colors.light}
+  border-radius: 1rem;
+  transition: all 300ms;
+
+  ${HiddenCheckbox}:focus + & {
+    box-shadow: 0 0 0 5px ${colors.highlight_primary};
+  }
+`;
+
+const CheckboxContainer = styled.div`
+  display: flex;
+  margin-top: 1em;
+  cursor: pointer;
+`;
+
+const LabelText = styled.span`
+  line-height: 2rem;
+  padding-left: 0.5rem;
+`;
+
+const Checkbox = ({ checked, label, onChange, ...props }) => (
+  <CheckboxContainer onClick={() => onChange({ target: { name: props.name, value: !checked } })}>
+    <HiddenCheckbox checked={checked} onChange={() => {}} {...props} />
+    <StyledCheckbox checked={checked} />
+    <LabelText>{label}</LabelText>
+  </CheckboxContainer>
+);
+
+Checkbox.propTypes = {
+  checked: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  label: PropTypes.string,
+  name: PropTypes.string,
+  onChange: PropTypes.func,
+};
+
+Checkbox.defaultProps = {
+  checked: false,
+  label: null,
+  name: '',
+  onChange: () => {},
+};
+
+export default Checkbox;


### PR DESCRIPTION
**Changes**

- Create a new simpler/better custom checkbox
- Use it on the visitor details page to allow contact consent to be changed

**Manual testing:**

- [x] Change contact consent of a visitor and press save
- [x] if I add an activity with spaces at the beginning of the name they are removed when added

**Partnered PR:** https://github.com/TwinePlatform/twine-api/pull/367