### PR TITLE
✨ add confirm role page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ import Login from './cb_admin/pages/Login';
 import PrivateRoute from './auth/PrivateRoute';
 import ResetPassword from './cb_admin/pages/ResetPassword';
 import ForgotPassword from './cb_admin/pages/ForgotPassword';
+import ConfirmRole from './confirm_role/pages/ConfirmRole';
 
 
 const ProtectedRoutes = () => (
@@ -34,6 +35,7 @@ const App = () => (
         <Route exact path="/login" component={Login} />
         <Route exact path="/password/reset/:token" component={ResetPassword} />
         <Route exact path="/password/forgot" component={ForgotPassword} />
+        <Route exact path="/confirm-role/:token" component={ConfirmRole} />
         <PrivateRoute path="/*" component={ProtectedRoutes} />
       </Switch>
     </Container>

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -111,6 +111,8 @@ export const Visitors = {
         visitActivityId: activityId,
       },
     ),
+  addRole: ({ userId, organisationId, role, token } = {}) =>
+    axios.post('/users/register/confirm', { userId, organisationId, role, token }),
 };
 
 export const CbAdmin = {
@@ -190,5 +192,5 @@ export const ErrorUtils = {
 };
 
 export const ResponseUtils = {
-  getResponse: (maybeArray = [], obj) => pathOr(null, ['data', 'result', ...maybeArray], obj),
+  getResponse: (obj, maybeArray = []) => pathOr(null, ['data', 'result', ...maybeArray], obj),
 };

--- a/src/cb_admin/pages/ConfirmPassword.js
+++ b/src/cb_admin/pages/ConfirmPassword.js
@@ -33,7 +33,7 @@ class ConfirmPassword extends React.Component {
 
   componentDidMount() {
     CbAdmin.get()
-      .then(res => this.setState({ email: ResponseUtils.getResponse(['email'], res) }))
+      .then(res => this.setState({ email: ResponseUtils.getResponse(res, ['email']) }))
       .catch(error => redirectOnError(this.props.history.push, error));
   }
   onChange = e => this.setState({ [e.target.name]: e.target.value });

--- a/src/confirm_role/pages/ConfirmRole.js
+++ b/src/confirm_role/pages/ConfirmRole.js
@@ -47,24 +47,15 @@ export default class ConfirmRole extends Component {
     const { userId, organisationId, role } = parse(search.replace('?', ''));
     Visitors.addRole({ token, userId, organisationId, role: role && role.toUpperCase() })
       .then((r) => {
-        console.log({ r });
-
         const res = ResponseUtils.getResponse(r);
-        console.log({ res });
-
         return res.token
           ? this.setState({ status: status.REDIRECT, user: res })
           : this.setState({ status: status.SUCCESS });
       })
-      .catch((e) => {
-        console.log(e);
-
-        this.setState({
-          status: status.FAILURE,
-          errors: ErrorUtils.getErrorMessage(e),
-        })
-        ;
-      });
+      .catch(e => this.setState({
+        status: status.FAILURE,
+        errors: ErrorUtils.getErrorMessage(e),
+      }));
   }
 
   render() {

--- a/src/confirm_role/pages/ConfirmRole.js
+++ b/src/confirm_role/pages/ConfirmRole.js
@@ -1,12 +1,11 @@
 import React, { Component } from 'react';
-import { Link, Redirect } from 'react-router-dom';
+import { Redirect } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { BeatLoader } from 'react-spinners';
 import { parse } from 'querystring';
 import { Heading, Paragraph } from '../../shared/components/text/base';
 import { FlexContainerCol } from '../../shared/components/layout/base';
-import DotButton from '../../shared/components/form/DottedButton';
 import NavHeader from '../../shared/components/NavHeader';
 import { Visitors, ResponseUtils, ErrorUtils } from '../../api';
 import { colors } from '../../shared/style_guide';

--- a/src/confirm_role/pages/ConfirmRole.js
+++ b/src/confirm_role/pages/ConfirmRole.js
@@ -3,9 +3,9 @@ import { Redirect } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { BeatLoader } from 'react-spinners';
+import { Col } from 'react-flexbox-grid';
 import { parse } from 'querystring';
 import { Heading, Paragraph } from '../../shared/components/text/base';
-import { FlexContainerCol } from '../../shared/components/layout/base';
 import NavHeader from '../../shared/components/NavHeader';
 import { Visitors, ResponseUtils, ErrorUtils } from '../../api';
 import { colors } from '../../shared/style_guide';
@@ -60,7 +60,7 @@ export default class ConfirmRole extends Component {
 
   render() {
     return (
-      <FlexContainerCol justify="flex-start">
+      <Col>
         <NavHeader
           centerContent={
             <Heading>Add {this.state.role} Role</Heading>
@@ -93,7 +93,7 @@ export default class ConfirmRole extends Component {
           )}
 
         </StyledSection>
-      </FlexContainerCol>
+      </Col>
     );
   }
 }

--- a/src/confirm_role/pages/ConfirmRole.js
+++ b/src/confirm_role/pages/ConfirmRole.js
@@ -32,13 +32,8 @@ const status = {
 export default class ConfirmRole extends Component {
   constructor(props) {
     super(props);
-
-    const { props: { location: { search } } } = this;
-    const { role } = parse(search.replace('?', ''));
-
     this.state = {
       status: status.PENDING,
-      role,
     };
   }
 
@@ -59,11 +54,12 @@ export default class ConfirmRole extends Component {
   }
 
   render() {
+    const { role } = parse(this.props.location.search.replace('?', ''));
     return (
       <Col>
         <NavHeader
           centerContent={
-            <Heading>Add {this.state.role} Role</Heading>
+            <Heading>Add {role} Role</Heading>
           }
         />
         <StyledSection>

--- a/src/confirm_role/pages/ConfirmRole.js
+++ b/src/confirm_role/pages/ConfirmRole.js
@@ -1,0 +1,114 @@
+import React, { Component } from 'react';
+import { Link, Redirect } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { BeatLoader } from 'react-spinners';
+import { parse } from 'querystring';
+import { Heading, Paragraph } from '../../shared/components/text/base';
+import { FlexContainerCol } from '../../shared/components/layout/base';
+import DotButton from '../../shared/components/form/DottedButton';
+import NavHeader from '../../shared/components/NavHeader';
+import { Visitors, ResponseUtils, ErrorUtils } from '../../api';
+import { colors } from '../../shared/style_guide';
+
+
+const StyledSection = styled.section`
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  text-align: center;
+`;
+
+const ErrorText = styled(Paragraph)`
+  color: ${colors.error};
+`;
+
+const status = {
+  PENDING: 'PENDING',
+  SUCCESS: 'SUCCESS',
+  REDIRECT: 'REDIRECT',
+  FAILURE: 'FAILURE',
+};
+
+export default class ConfirmRole extends Component {
+  constructor(props) {
+    super(props);
+
+    const { props: { location: { search } } } = this;
+    const { role } = parse(search.replace('?', ''));
+
+    this.state = {
+      status: status.PENDING,
+      role,
+    };
+  }
+
+  componentDidMount() {
+    const { props: { location: { search }, match: { params: { token } } } } = this;
+    const { userId, organisationId, role } = parse(search.replace('?', ''));
+    Visitors.addRole({ token, userId, organisationId, role: role && role.toUpperCase() })
+      .then((r) => {
+        console.log({ r });
+
+        const res = ResponseUtils.getResponse(r);
+        console.log({ res });
+
+        return res.token
+          ? this.setState({ status: status.REDIRECT, user: res })
+          : this.setState({ status: status.SUCCESS });
+      })
+      .catch((e) => {
+        console.log(e);
+
+        this.setState({
+          status: status.FAILURE,
+          errors: ErrorUtils.getErrorMessage(e),
+        })
+        ;
+      });
+  }
+
+  render() {
+    return (
+      <FlexContainerCol justify="flex-start">
+        <NavHeader
+          centerContent={
+            <Heading>Add {this.state.role} Role</Heading>
+          }
+        />
+        <StyledSection>
+          {this.state.status === status.PENDING && (
+            <BeatLoader
+              color={colors.highlight_primary}
+              sizeUnit={'px'}
+              size={15}
+            />
+          )}
+          {this.state.status === status.SUCCESS && (
+            <Paragraph>
+            Visitor account has been created. See email for QR code.
+            </Paragraph>
+          )}
+          {this.state.status === status.REDIRECT && (
+            <Redirect to={{ pathname: `/password/reset/${this.state.user.token}?email=${this.state.user.email}` }} />
+          )}
+          {this.state.status === status.FAILURE && (
+            <>
+              <ErrorText>{this.state.errors}</ErrorText>
+              <Paragraph>
+               Sorry there has been an error creating your account.
+               Please talk to your Community Business about setting up an account
+              </Paragraph>
+            </>
+          )}
+
+        </StyledSection>
+      </FlexContainerCol>
+    );
+  }
+}
+
+ConfirmRole.propTypes = {
+  location: PropTypes.shape({ search: PropTypes.string }).isRequired,
+  match: PropTypes.shape({ params: PropTypes.string }).isRequired,
+};


### PR DESCRIPTION
Related to TwinePlatform/hq#57

#### Changes:
- accept values from querystring and url
- attempt to create account
- display message if visitor account is created
- display error message if there was a problem
- redirect to pw reset if volunteer account

Partnered PR: https://github.com/TwinePlatform/twine-api/pull/371

#### Manual Testing:
- visitor second role
  - sign up to visitor app with email used as a volunteer
  - respond to confirmation email
  - webpage will tell you its a success
- volunteer second role
  - sign up to volunteer app with email used as a visitor
  - respond to confirmation email
  - webpage will redirect you to password reset to set your password
- error 
  - go to page with a used cookie will give you an error message
  - go to page with bad/edited query string will give you an error message

#### Notes:
- no testing in favour of adding once monorepo is set up